### PR TITLE
No Deletes

### DIFF
--- a/src/htdocs/modules/admin/ProductFactory.js
+++ b/src/htdocs/modules/admin/ProductFactory.js
@@ -35,27 +35,12 @@ var ProductFactory = function (/*options*/) {
    *         delete product.
    */
   _this.getDelete = function (product) {
-    var code,
-        properties,
-        source,
-        type;
+    var attributes;
 
-    product = _getProduct(product);
-    code = product.get('code');
-    properties = product.get('properties');
-    source = product.get('source');
-    type = product.get('type');
+    attributes = _getProduct(product).toJSON();
+    attributes.status = Product.STATUS_DELETE;
 
-    return Product({
-      source: source,
-      type: type,
-      status: Product.STATUS_DELETE,
-      code: code,
-      properties: {
-        eventsource: properties.eventsource,
-        eventsourcecode: properties.eventsourcecode
-      }
-    });
+    return Product(attributes);
   };
 
   /**

--- a/src/htdocs/modules/admin/scientific/ScientificSummaryPage.js
+++ b/src/htdocs/modules/admin/scientific/ScientificSummaryPage.js
@@ -75,7 +75,8 @@ AdminScientificSummaryPage.prototype.getLinks = function () {
   // add link products
   links = this._event.properties.products['scitech-link'];
   if (links) {
-    links = CatalogEvent.getWithoutSuperseded(links);
+    links = CatalogEvent.getWithoutDeleted(
+        CatalogEvent.getWithoutSuperseded(links));
     links.forEach(function (product) {
       var el = document.createElement('li');
       el.appendChild(this.getLink(product));
@@ -173,7 +174,8 @@ AdminScientificSummaryPage.prototype._getAddLinkClick = function () {
   fragment.appendChild(el);
   texts = this._event.properties.products[type];
   if (texts) {
-    texts = CatalogEvent.getWithoutSuperseded(texts);
+    texts = CatalogEvent.getWithoutDeleted(
+        CatalogEvent.getWithoutSuperseded(texts));
     texts.forEach(function (product) {
       fragment.appendChild(this.getText(product));
     }, this);

--- a/src/htdocs/modules/admin/summary/SummaryPage.js
+++ b/src/htdocs/modules/admin/summary/SummaryPage.js
@@ -63,7 +63,9 @@ AdminSummaryPage.prototype._getTexts = function (type) {
   fragment.appendChild(el);
   texts = this._event.properties.products[type];
   if (texts) {
-    texts = CatalogEvent.getWithoutSuperseded(texts);
+    texts = CatalogEvent.getWithoutDeleted(
+        CatalogEvent.getWithoutSuperseded(texts));
+
     texts.forEach(function (product) {
       fragment.appendChild(this._getText(product));
     }, this);
@@ -138,7 +140,9 @@ AdminSummaryPage.prototype._getLinks = function () {
   // add link products
   links = this._event.properties.products['general-link'];
   if (links) {
-    links = CatalogEvent.getWithoutSuperseded(links);
+    links = CatalogEvent.getWithoutDeleted(
+        CatalogEvent.getWithoutSuperseded(links));
+
     links.forEach(function (product) {
       var el = document.createElement('li');
       el.appendChild(this._getLink(product));


### PR DESCRIPTION
Suppress deletes from scientific/general summary page. It seems confusing to continue to show deleted products where they _would_ be displayed if they weren't deleted.