### PR TITLE
Changed region property to title. This is what indexer expects.

### DIFF
--- a/src/htdocs/modules/admin/EditProductView.js
+++ b/src/htdocs/modules/admin/EditProductView.js
@@ -14,7 +14,7 @@ var ContentsManagerView = require('ContentsManagerView'),
 
 
 var PRIORITY_PROPERTIES = {
-  'region': {
+  'title': {
     type: 'text',
     label: 'Region Name',
     help: 'If this product&rsquo;s type is &ldquo;origin&rdquo; then this ' +


### PR DESCRIPTION
The event summarization process is looking for a property called "title", not "region". This makes it so an admin can set the event title via the admin pages.
