### PR TITLE
Sender Email

### DIFF
--- a/src/htdocs/send_product.php
+++ b/src/htdocs/send_product.php
@@ -39,6 +39,7 @@ try {
   $sender->setCommand('java -jar ' . escapeshellarg($CONFIG['PDL_JAR_FILE']));
   $sender->setServers($CONFIG['PDL_SERVERS']);
   $sender->setWorkingDir($workingDir);
+  $sender->setSentByEmail($_SESSION['username']);
   if (file_exists($CONFIG['PDL_PRIVATE_KEY'])) {
     $sender->setPrivateKeyFile($CONFIG['PDL_PRIVATE_KEY']);
   }


### PR DESCRIPTION
Using session username as sender email for tracking purposes.

Check the general-link product for this event on the dev systems:
https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?eventid=nn00678328